### PR TITLE
fix: properly map VERIFY_SSL config to zbx ZABBIX_VERIFY_TLS format

### DIFF
--- a/bin/merger.sh
+++ b/bin/merger.sh
@@ -1119,7 +1119,12 @@ cmd_validate() {
                     echo "export ZABBIX_USER='${ZABBIX_USER:-}'"
                     echo "export ZABBIX_PASS='${ZABBIX_PASSWORD:-}'"
                 fi
-                echo "export ZABBIX_VERIFY_TLS=true"
+                # Map VERIFY_SSL to ZABBIX_VERIFY_TLS (zbx expects 0 or 1)
+                if [ "${VERIFY_SSL:-true}" = "false" ]; then
+                    echo "export ZABBIX_VERIFY_TLS=0"
+                else
+                    echo "export ZABBIX_VERIFY_TLS=1"
+                fi
                 echo "export ZABBIX_CURL_TIMEOUT=30"
             } > "${temp_zbx_config}"
 
@@ -1322,7 +1327,12 @@ cmd_validate() {
                         # zbx uses ZABBIX_PASS, not ZABBIX_PASSWORD
                         echo "export ZABBIX_PASS='${ZABBIX_PASSWORD:-}'"
                     fi
-                    echo "export ZABBIX_VERIFY_TLS=true"
+                    # Map VERIFY_SSL to ZABBIX_VERIFY_TLS (zbx expects 0 or 1)
+                    if [ "${VERIFY_SSL:-true}" = "false" ]; then
+                        echo "export ZABBIX_VERIFY_TLS=0"
+                    else
+                        echo "export ZABBIX_VERIFY_TLS=1"
+                    fi
                     echo "export ZABBIX_CURL_TIMEOUT=30"
                 } > "${temp_zbx_config}"
                 chmod +x "${temp_zbx_config}"


### PR DESCRIPTION
## Summary
This PR fixes the TLS verification mapping between asset-merger-engine and zbx configurations.

## Changes
- Properly maps `VERIFY_SSL` configuration to zbx's `ZABBIX_VERIFY_TLS` format
- Ensures `VERIFY_SSL="false"` maps to `ZABBIX_VERIFY_TLS=0`
- Ensures `VERIFY_SSL="true"` maps to `ZABBIX_VERIFY_TLS=1`
- zbx expects numeric 0/1 values, not boolean true/false strings

## Testing
The changes have been tested and verified to work correctly with both SSL verification enabled and disabled scenarios.

## Impact
This fix ensures proper SSL/TLS verification behavior when the merger validates zbx connectivity, respecting the user's SSL verification preferences.