### PR TITLE
feat: add Topdesk configuration display in diagnostics

### DIFF
--- a/bin/merger.sh
+++ b/bin/merger.sh
@@ -1447,6 +1447,28 @@ cmd_validate() {
                     printf "%s\n" "----------------------------------------"
                 fi
 
+                # Always show our Topdesk configuration for debugging
+                printf "\n%bTopdesk Configuration (from asset-merger-engine):%b\n" "${CYAN}" "${NC}"
+                printf "Using temporary config: %s\n" "${temp_td_config}"
+                printf "%s\n" "----------------------------------------"
+                printf "TOPDESK_URL=%s\n" "${TOPDESK_URL:-}"
+                printf "TOPDESK_USER=%s\n" "${TOPDESK_USER:-}"
+                if [ -n "${TOPDESK_PASSWORD:-}" ]; then
+                    # Mask password like zbx does
+                    local masked_pass=$(printf "%s" "${TOPDESK_PASSWORD}" | sed 's/^\(...\).*/\1***/')
+                    printf "TOPDESK_PASSWORD=%s\n" "${masked_pass}"
+                else
+                    printf "TOPDESK_PASSWORD=\n"
+                fi
+                printf "TOPDESK_API_TOKEN=%s\n" "${TOPDESK_API_TOKEN:-}"
+                if [ "${VERIFY_SSL:-true}" = "false" ]; then
+                    printf "TOPDESK_VERIFY_SSL=false\n"
+                else
+                    printf "TOPDESK_VERIFY_SSL=true\n"
+                fi
+                printf "TOPDESK_TIMEOUT=%s\n" "${TOPDESK_TIMEOUT:-${CONNECT_TIMEOUT:-30}}"
+                printf "%s\n" "----------------------------------------"
+
                 # Clean up temp config
                 rm -f "${temp_td_config}"
                 unset TOPDESK_CONFIG


### PR DESCRIPTION
## Summary
This PR adds a configuration display for Topdesk in the diagnostics output, ensuring users can always verify their configuration is being properly loaded.

## Problem
- When the topdesk CLI tool is broken or misconfigured, there was no way to see what configuration was being applied
- This made debugging configuration issues difficult
- The zbx CLI shows its configuration, but topdesk didn't

## Solution
Added a configuration display section that shows:
- TOPDESK_URL
- TOPDESK_USER
- TOPDESK_PASSWORD (masked as xxx***)
- TOPDESK_API_TOKEN
- TOPDESK_VERIFY_SSL (true/false based on VERIFY_SSL config)
- TOPDESK_TIMEOUT

## Testing
Tested with:
- ✅ VERIFY_SSL=true shows TOPDESK_VERIFY_SSL=true
- ✅ VERIFY_SSL=false shows TOPDESK_VERIFY_SSL=false
- ✅ Password is properly masked
- ✅ Configuration displays even when topdesk CLI is broken

## Example Output
```
Topdesk Configuration (from asset-merger-engine):
Using temporary config: /tmp/topdesk_doctor_12345.sh
----------------------------------------
TOPDESK_URL=https://topdesk.example.com
TOPDESK_USER=apiuser
TOPDESK_PASSWORD=cha***
TOPDESK_API_TOKEN=
TOPDESK_VERIFY_SSL=true
TOPDESK_TIMEOUT=30
----------------------------------------
```

This matches the format and behavior of the Zabbix configuration display.