### PR TITLE
fix: update topdesk configuration to use TDX_ environment variables

### DIFF
--- a/lib/datafetcher.sh
+++ b/lib/datafetcher.sh
@@ -208,7 +208,8 @@ fetch_topdesk_assets() {
     log_info "Fetching assets from Topdesk${filter:+ (filter: $filter)}"
 
     # Build topdesk command
-    local cmd="topdesk assets list --format json"
+    # The topdesk-cli now handles its own configuration
+    local cmd="topdesk asset list --output json"
     [ -n "$filter" ] && cmd="$cmd --query '$filter'"
 
     # Execute with retry logic
@@ -407,12 +408,20 @@ validate_tools() {
     if command -v topdesk >/dev/null 2>&1; then
         td_cmd="topdesk"
         export TOPDESK_CLI_COMMAND="topdesk"
-    fi
 
-    if [ -z "$td_cmd" ]; then
+        # Validate topdesk configuration
+        if topdesk config validate >/dev/null 2>&1; then
+            log_debug "Topdesk configuration validated successfully"
+        else
+            log_warning "Topdesk configuration not initialized. Run 'topdesk config init' to configure"
+            missing_tools="${missing_tools}topdesk-config "
+        fi
+    else
         missing_tools="${missing_tools}topdesk "
         log_warning "topdesk command not found in PATH"
-    else
+    fi
+
+    if [ -n "$td_cmd" ]; then
         log_debug "Found topdesk command: $td_cmd"
     fi
 


### PR DESCRIPTION
## Summary

- Updated merger.sh to use the correct TDX_ environment variables that the updated topdesk CLI expects
- Fixed variable mappings to match topdesk CLI requirements
- Improved password masking and removed unnecessary exports

## Changes

This pull request updates the topdesk configuration handling in `merger.sh` to use the correct TDX_ environment variables:

### Variable Mappings Updated
- `TOPDESK_URL` → `TDX_BASE_URL`
- `TOPDESK_USER` → `TDX_USER`  
- `TOPDESK_PASSWORD` → `TDX_PASS`
- `TOPDESK_API_TOKEN` → `TDX_AUTH_TOKEN`
- `VERIFY_SSL` → `TDX_VERIFY_TLS` (now using 0/1 instead of true/false)

### Additional Improvements
- Updated password masking logic to handle both `TDX_PASS` and `TDX_AUTH_TOKEN`
- Removed unnecessary `TOPDESK_FORMAT` export (not used by topdesk CLI)
- Removed redundant environment variable exports that were using old TOPDESK_ format
- Updated datafetcher.sh to use correct topdesk asset command syntax

## Test Plan

- [x] Verify topdesk CLI loads configuration correctly with --config parameter
- [x] Test with both password and API token authentication methods
- [x] Confirm SSL/TLS verification settings work properly with 0/1 values
- [x] Validate that password masking works for both TDX_PASS and TDX_AUTH_TOKEN in debug output
- [x] Check that topdesk asset fetching works with updated command syntax