### PR TITLE
Clean up topdesk validation output

### DIFF
--- a/bin/merger.sh
+++ b/bin/merger.sh
@@ -1407,12 +1407,7 @@ cmd_validate() {
                     printf "%s\n" "----------------------------------------"
                 fi
 
-                if [ $topdesk_has_config -eq 1 ]; then
-                    printf "\nRunning: topdesk --config %s config\n" "${temp_td_config}"
-                    printf "%s\n" "----------------------------------------"
-                    topdesk --config "${temp_td_config}" config 2>&1 || printf "topdesk config failed with exit code: $?\n"
-                    printf "%s\n" "----------------------------------------"
-                fi
+                # Skip generic config command - we'll show config list later which is more useful
 
                 if [ $topdesk_has_test -eq 1 ]; then
                     printf "\nRunning: topdesk --config %s test\n" "${temp_td_config}"
@@ -1421,7 +1416,7 @@ cmd_validate() {
                     printf "%s\n" "----------------------------------------"
                 fi
 
-                if [ $topdesk_has_doctor -eq 0 ] && [ $topdesk_has_config -eq 0 ] && [ $topdesk_has_test -eq 0 ]; then
+                if [ $topdesk_has_doctor -eq 0 ] && [ $topdesk_has_test -eq 0 ]; then
                     printf "No diagnostic commands available for topdesk CLI\n"
                     printf "Trying: topdesk --config %s --version\n" "${temp_td_config}"
                     printf "%s\n" "----------------------------------------"


### PR DESCRIPTION
## Summary
- Removed duplicate topdesk configuration display in the validate command
- Cleaned up validation output to avoid redundancy

## Changes
1. **Removed duplicate config display**: The generic `topdesk config` command that only showed help text has been removed from the validation flow
2. **Kept useful config display**: Only `topdesk config list` is now shown, which displays the actual configuration values
3. **Updated condition check**: Removed the check for `topdesk_has_config` variable since it's no longer being used in the validation logic

## Impact
This makes the validation output cleaner and more focused by:
- Avoiding showing the topdesk configuration twice
- Only displaying commands that provide useful diagnostic information
- Reducing noise in the validation report

## Test Plan
- [x] Verified that validation still runs successfully
- [x] Confirmed that `topdesk config list` still displays configuration values
- [x] Checked that the validation report is cleaner without duplicate information