### PR TITLE
fix: remove nonexistent topdesk version command fallback

### DIFF
--- a/bin/merger.sh
+++ b/bin/merger.sh
@@ -1225,7 +1225,7 @@ cmd_validate() {
             chmod +x "${temp_td_config}"
 
             if [ "${DEBUG}" = "1" ]; then
-                printf "\n  Testing with: topdesk test/version\n"
+                printf "\n  Testing with: topdesk ping\n"
                 printf "  URL: %s\n" "${TOPDESK_URL}"
                 if [ -n "${TOPDESK_API_TOKEN:-}" ]; then
                     printf "  Auth: API Token\n"
@@ -1246,15 +1246,6 @@ cmd_validate() {
                 else
                     test_result=$?
                     printf "  topdesk ping failed with exit code: %s\n" "${test_result}"
-                    # Try version as alternate test
-                    printf "  Trying: topdesk version\n"
-                    if topdesk --config "${temp_td_config}" version 2>&1; then
-                        test_result=0
-                        printf "  "
-                    else
-                        test_result=$?
-                        printf "  topdesk version failed with exit code: %s\n" "${test_result}"
-                    fi
                     printf "  "
                 fi
             else
@@ -1262,12 +1253,7 @@ cmd_validate() {
                 if topdesk --config "${temp_td_config}" ping >/dev/null 2>&1; then
                     test_result=0
                 else
-                    # Try version as fallback
-                    if topdesk --config "${temp_td_config}" version >/dev/null 2>&1; then
-                        test_result=0
-                    else
-                        test_result=1
-                    fi
+                    test_result=1
                 fi
             fi
 


### PR DESCRIPTION
## Summary
- Removed fallback to the nonexistent `topdesk version` command in validation logic
- Now only using `topdesk ping` for connectivity testing to avoid unnecessary errors
- Updated debug message to accurately reflect the command being used

## Changes
The topdesk CLI doesn't have a `version` command, so the fallback was causing errors when the `ping` command failed. This PR removes those fallback attempts:

1. **Debug mode** (lines 1249-1257): Removed the fallback attempt to `topdesk version` after `ping` failure
2. **Silent mode** (lines 1265-1269): Removed the fallback to `topdesk version` command  
3. **Debug message**: Updated from "Testing with: topdesk test/version" to "Testing with: topdesk ping"

## Test Plan
- [ ] Verify that `merger.sh validate` command works correctly with valid TopDesk credentials
- [ ] Verify that validation properly fails with invalid credentials (no longer attempts version command)
- [ ] Test both debug mode (`-d` flag) and silent mode
- [ ] Confirm no regression in other validation checks