### PR TITLE
fix: resolve SCRIPT_DIR readonly conflict in library files

### DIFF
--- a/lib/cli_wrapper.sh
+++ b/lib/cli_wrapper.sh
@@ -1,13 +1,12 @@
 #!/bin/sh
 # cli_wrapper.sh - Unified CLI wrapper with fallback/mock support
 
-# Source dependencies
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-. "${SCRIPT_DIR}/common.sh" 2>/dev/null || true
+# Source dependencies (use LIB_DIR from parent script)
+. "${LIB_DIR:-$(dirname "$0")}/common.sh" 2>/dev/null || true
 
 # Configuration
 MOCK_MODE="${MOCK_MODE:-auto}"  # auto, true, false
-MOCK_DATA_DIR="${MOCK_DATA_DIR:-${SCRIPT_DIR}/../test/mock_data}"
+MOCK_DATA_DIR="${MOCK_DATA_DIR:-${PROJECT_ROOT:-..}/test/mock_data}"
 
 # Detect if CLI tools are available
 detect_cli_tools() {
@@ -51,7 +50,7 @@ zbx_execute_wrapper() {
         fi
 
         # Source the actual wrapper
-        . "${SCRIPT_DIR}/zbx_cli_wrapper.sh"
+        . "${LIB_DIR:-$(dirname "$0")}/zbx_cli_wrapper.sh"
         zbx_execute "$command"
     fi
 }
@@ -71,7 +70,7 @@ td_execute_wrapper() {
         fi
 
         # Source the actual wrapper
-        . "${SCRIPT_DIR}/topdesk_cli_wrapper.sh"
+        . "${LIB_DIR:-$(dirname "$0")}/topdesk_cli_wrapper.sh"
         td_execute "$command"
     fi
 }

--- a/lib/datafetcher.sh
+++ b/lib/datafetcher.sh
@@ -2,9 +2,8 @@
 # datafetcher.sh - Data retrieval module for asset-merger-engine
 # Fetches asset information from Zabbix and Topdesk systems
 
-# Source dependencies
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-. "${SCRIPT_DIR}/common.sh" 2>/dev/null || true
+# Source dependencies (use LIB_DIR from parent script)
+. "${LIB_DIR:-$(dirname "$0")}/common.sh" 2>/dev/null || true
 
 # Configuration
 CACHE_DIR="${CACHE_DIR:-/tmp/asset-merger-engine/cache}"

--- a/lib/topdesk_cli_wrapper.sh
+++ b/lib/topdesk_cli_wrapper.sh
@@ -1,10 +1,9 @@
 #!/bin/sh
 # topdesk_cli_wrapper.sh - Topdesk CLI wrapper with enhanced functionality
 
-# Source common utilities
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-. "${SCRIPT_DIR}/common.sh"
-. "${SCRIPT_DIR}/auth_manager.sh" 2>/dev/null || true
+# Source common utilities (use LIB_DIR from parent script)
+. "${LIB_DIR:-$(dirname "$0")}/common.sh"
+. "${LIB_DIR:-$(dirname "$0")}/auth_manager.sh" 2>/dev/null || true
 
 # Topdesk-specific configuration
 TD_TIMEOUT="${TD_TIMEOUT:-30}"

--- a/lib/zbx_cli_wrapper.sh
+++ b/lib/zbx_cli_wrapper.sh
@@ -1,10 +1,9 @@
 #!/bin/sh
 # zbx_cli_wrapper.sh - Zabbix CLI wrapper with enhanced functionality
 
-# Source common utilities
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-. "${SCRIPT_DIR}/common.sh"
-. "${SCRIPT_DIR}/auth_manager.sh" 2>/dev/null || true
+# Source common utilities (use LIB_DIR from parent script)
+. "${LIB_DIR:-$(dirname "$0")}/common.sh"
+. "${LIB_DIR:-$(dirname "$0")}/auth_manager.sh" 2>/dev/null || true
 
 # Zabbix-specific configuration
 ZBX_TIMEOUT="${ZBX_TIMEOUT:-30}"


### PR DESCRIPTION
## Problem
When running `asset-merger-engine fetch --group <GROUP>`, the following error occurred:
```
datafetcher.sh: SCRIPT_DIR: is readonly
```

This happened because:
- `merger.sh` declares `readonly SCRIPT_DIR` on line 15
- Library files that get sourced also tried to set `SCRIPT_DIR`
- Shell doesn't allow reassigning readonly variables

## Solution
Removed SCRIPT_DIR assignments from library files that are meant to be sourced, not executed directly. They now use `${LIB_DIR:-$(dirname "$0")}` pattern which:
- Respects the parent script's LIB_DIR variable
- Provides a fallback for direct execution during development

## Changes
### Files Modified
- **lib/datafetcher.sh**: Use LIB_DIR for sourcing common.sh
- **lib/cli_wrapper.sh**: Use LIB_DIR and PROJECT_ROOT for paths
- **lib/zbx_cli_wrapper.sh**: Use LIB_DIR for sourcing dependencies
- **lib/topdesk_cli_wrapper.sh**: Use LIB_DIR for sourcing dependencies

### Files Not Changed
- **lib/demo_datafetcher.sh**: Standalone executable script, needs its own SCRIPT_DIR
- **lib/test_datafetcher.sh**: Standalone executable script, needs its own SCRIPT_DIR

## Testing
✅ Verified `./bin/merger.sh validate` runs without SCRIPT_DIR errors
✅ Library files can still be sourced correctly
✅ Demo and test scripts remain executable