### PR TITLE
fix: update zbx command syntax to use zbx call API

### DIFF
--- a/lib/datafetcher.sh
+++ b/lib/datafetcher.sh
@@ -78,8 +78,8 @@ fetch_zabbix_assets() {
 
     log_info "Fetching assets from Zabbix (group: $group)"
 
-    # Build zbx command for getting hosts in a group
-    local cmd="zbx --format json host list --hostgroup '$group'"
+    # Build zbx call command for getting hosts in a group using JSON-RPC API
+    local cmd="echo '{\"selectGroups\":\"extend\",\"selectInterfaces\":\"extend\",\"selectInventory\":\"extend\",\"filter\":{\"groups\":[\"'\"$group\"'\"]}}' | zbx call host.get"
 
     # Execute with retry logic
     local raw_output


### PR DESCRIPTION
## Problem
When running `asset-merger-engine fetch --group <GROUP>`, the zbx command was malformed, resulting in error messages:
```
Run zbx help to see all commands
```

The root cause was using an obsolete command syntax:
```bash
zbx --format json host list --hostgroup 'Topdesk'
```

This command doesn't exist in the current zbx CLI. The CLI uses:
- Commands with hyphens (e.g., `hosts-list`, `host-get`)  
- No direct `--hostgroup` filtering option on simple list commands

## Solution
Updated to use the low-level `zbx call` command with proper JSON-RPC API parameters:

```bash
echo '{"selectGroups":"extend","selectInterfaces":"extend","selectInventory":"extend","filter":{"groups":["Topdesk"]}}' | zbx call host.get
```

This:
1. Uses the correct `zbx call host.get` syntax for JSON-RPC calls
2. Filters hosts by group name using the Zabbix API `filter` parameter
3. Includes complete host data (groups, interfaces, inventory) in one call
4. Returns proper JSON output for the existing normalize_zabbix_data function

## Changes
**lib/datafetcher.sh line 82:**
- Before: `local cmd="zbx --format json host list --hostgroup '$group'"`
- After: `local cmd="echo '{\"selectGroups\":\"extend\",\"selectInterfaces\":\"extend\",\"selectInventory\":\"extend\",\"filter\":{\"groups\":[\"'\"$group\"'\"]}}' | zbx call host.get"`

## Testing
✅ Command syntax validated with `zbx help call`
✅ Verified JSON-RPC parameter structure matches Zabbix API host.get documentation
✅ Tested command executes without "Run zbx help" errors