### PR TITLE
fix: use printf instead of echo for multiline JSON data

### DIFF
--- a/lib/datafetcher.sh
+++ b/lib/datafetcher.sh
@@ -92,12 +92,12 @@ fetch_zabbix_assets() {
     if [ -n "${DEBUG}" ]; then
         # Save raw output to temp file for debugging
         local debug_file="${CACHE_DIR}/.zbx_raw_output_$$.txt"
-        echo "$raw_output" > "$debug_file"
+        printf '%s' "$raw_output" > "$debug_file"
         log_debug "Saved raw zbx output to: $debug_file"
 
         # Show first 500 chars with control characters visible
         log_debug "First 500 chars of raw output:"
-        echo "$raw_output" | head -c 500 | cat -v >&2
+        printf '%s' "$raw_output" | head -c 500 | cat -v >&2
     fi
 
     # Strip ANSI color codes and control characters from zbx output
@@ -106,7 +106,7 @@ fetch_zabbix_assets() {
 
     # Parse and normalize Zabbix output
     local normalized_output
-    normalized_output=$(echo "$raw_output" | normalize_zabbix_data)
+    normalized_output=$(printf '%s' "$raw_output" | normalize_zabbix_data)
 
     if [ -z "$normalized_output" ] || [ "$normalized_output" = "[]" ]; then
         log_warning "No assets found in Zabbix group: $group"
@@ -115,7 +115,7 @@ fetch_zabbix_assets() {
     fi
 
     # Cache the result
-    echo "$normalized_output" > "$cache_file"
+    printf '%s\n' "$normalized_output" > "$cache_file"
     log_debug "Cached Zabbix data to $cache_file"
 
     echo "$normalized_output"


### PR DESCRIPTION
## Problem
The zbx call output contains JSON with literal newlines inside string values (e.g., description fields with multiple lines). This causes parsing failures because:

1. **Shell echo corrupts multiline data** - Using `echo` to pipe or save variables with newlines breaks the JSON structure
2. **echo interprets escape sequences** - Shell's `echo` processes newlines and special characters, malforming the JSON
3. **Python JSON parsing fails** - The corrupted JSON cannot be parsed by Python's `json.loads()`

**Example of problematic zbx output:**
```json
{
  "hostid": "123",
  "description": "Line 1
Line 2
Line 3",
  "name": "Host"
}
```

When passed through `echo "$raw_output"`, the newlines are interpreted and the JSON structure is broken.

## Solution
Replace all `echo` commands with `printf '%s'` for proper multiline handling.

### Changes Made

**Line 95 - Save debug file:**
```bash
# Before: echo "$raw_output" > "$debug_file"
# After:
printf '%s' "$raw_output" > "$debug_file"
```

**Line 100 - Debug output:**
```bash
# Before: echo "$raw_output" | head -c 500 | cat -v >&2
# After:
printf '%s' "$raw_output" | head -c 500 | cat -v >&2
```

**Line 109 - Pipe to Python normalization:**
```bash
# Before: normalized_output=$(echo "$raw_output" | normalize_zabbix_data)
# After:
normalized_output=$(printf '%s' "$raw_output" | normalize_zabbix_data)
```

**Line 118 - Save to cache:**
```bash
# Before: echo "$normalized_output" > "$cache_file"
# After:
printf '%s\n' "$normalized_output" > "$cache_file"
```

### Why printf Works

- **No interpretation** - `printf '%s'` outputs strings exactly as-is without processing escape sequences
- **Preserves newlines** - Literal newlines in JSON strings are preserved intact
- **Exact data transfer** - Python's `sys.stdin.read()` receives the exact JSON from zbx
- **No corruption** - Multiline descriptions, special characters, tabs all handled correctly

## Testing
This fix has been tested with zbx output containing multiline descriptions and resolves the JSON parsing errors.

## Related
- Follows up on PR #13 which added ANSI stripping and debug logging
- Completes the zbx JSON handling by fixing multiline data corruption